### PR TITLE
Import and run tests in explict alphanumeric sort order

### DIFF
--- a/or_tests.bash
+++ b/or_tests.bash
@@ -131,7 +131,7 @@ then
     TEST_CLEANUP 1
 fi
 
-for utxml in $(ls *.xml | grep -v "^UnitTestFramework\.xml" | grep -v "^UnitTestRunner\.xml")
+for utxml in $(ls *.xml | grep -v "^UnitTestFramework\.xml" | grep -v "^UnitTestRunner\.xml" | sort)
 do
     utapp=$(basename $utxml .xml)
     w4gldev backupapp in ${TESTDB} $utapp $utxml -nreplace -xml -nowindows -Lorunittest.log -Tyes,logonly -A


### PR DESCRIPTION
NOTE this uses default sort options which means numbers before alphabetic
characters.