### PR TITLE
Change exit status for skipped test from -1 to 2

### DIFF
--- a/or_tests.bash
+++ b/or_tests.bash
@@ -208,7 +208,7 @@ do
         then
             printf "OK.\n"
         else
-			if [ $rv2 -eq -1 ]
+			if [ $rv2 -eq 2 ]
 			then
 				printf "OK (Some/or all tests have been SKIPPED).\n"
 			else

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -667,7 +667,7 @@ enddeclare
 					', Skipped=' + varchar(result.skipped.LastRow) + HC_NEWLINE;  
 
 	IF result.skipped.LastRow>0 THEN
-		CurSession.ExitCode=-1;
+		CurSession.ExitCode=2;
 		IF result.skipped.LastRow>0 THEN
 			CurProcedure.Trace(text= '=== Skipped Tests ===');
 		ENDIF;


### PR DESCRIPTION
Exit code -1 appears as 255 on Unix (range 0-255), so test for -1 in or_tests.bash failed.