### PR TITLE
Copy subdirs (e.g. resources) of unittests directory to test directory

### DIFF
--- a/or_tests.bash
+++ b/or_tests.bash
@@ -177,7 +177,7 @@ do
         makeimageflags=""
         if [ -f ${utapp}.cfg ]
         then
-            runner=`grep "^RUNNER=" ${utapp}.cfg | cut -f2 -d'='`
+            runner=`grep "^RUNNER=" ${utapp}.cfg | cut -f2 -d'=' | xargs echo -n`
             runflags=`grep "^RUNFLAGS=" ${utapp}.cfg | cut -f2 -d'='`
             makeimageflags=`grep "^MAKEIMAGEFLAGS=" ${utapp}.cfg | cut -f2 -d'='`
         fi

--- a/or_tests.bash
+++ b/or_tests.bash
@@ -126,12 +126,12 @@ then
 else
     display_log_file=${TESTDIR}/orunittest.log
 fi
-printf " Using logfile ${display_log_file} ...\n\n"
+printf " Using logfile %s ...\n\n" ${display_log_file}
 
 cd $TESTDIR
 TEST_CHECKCMD $? 0 "Y" "Unable to change into ${TESTDIR}"
 rm -f *.xml
-cp ${SCRIPTDIR}/unittests/* .
+cp -r ${SCRIPTDIR}/unittests/* .
 TEST_CHECKCMD $? 0 "Y" "Unable to copy unittests files into test directory ${TESTDIR}"
 
 if [ -z "$OR_UNITTEST_STATSFILE" ]
@@ -225,7 +225,7 @@ done
 printf "\nTest Statistics:\n\n"
 cat ${teststats}
 
-printf "\nDetailed log: ${display_log_file}\n"
+printf "\nDetailed log: %s\n" ${display_log_file}
 
 if [ $rc -ne 0 ]
 then

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -736,7 +736,7 @@ ENDDECLARE
 		CurObject.DirectorySeparator = '/';
 	ENDIF;
 
-	testdir = CurSession.GetEnv(name = 'TESTDIR');
+	testdir = CurSession.GetEnv(name = 'OR_UNITTEST_TESTDIR');
 	IF testdir = '' THEN
 		testdir = CurSession.WorkingDirectory;
 	ENDIF;


### PR DESCRIPTION
Additionally, corrections for printf statements as a Windows path could contain characters
which would be interpreted as formatting sequence (e.g. \t) by printf.