### PR TITLE
Do not chmod on unittest files causing a diff later

### DIFF
--- a/or_tests.bash
+++ b/or_tests.bash
@@ -94,7 +94,6 @@ export TESTDIR=$SCRIPTDIR/tests/test${TESTNO}
 echo '\q' | tm -S $TESTDB
 TEST_CHECKCMD $? 0 "Y" "Unable to connect to ${TESTDB}"
 
-chmod 644 *.xml unittests/*.xml
 mkdir -p $TESTDIR
 TEST_CHECKCMD $? 0 "Y" "Unable to create test directory $TESTDIR"
 


### PR DESCRIPTION
The "chmod" command eventually changes the mode for the unittest xml files.
This causes them to appear as diffs in a later "git diff" command if their original file mode was different, though the file content has not been changed.
The script should not change the file mode for the files.