### PR TITLE
Handled NULL parameters in Assert methods

### DIFF
--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OPENROAD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!-- Copyright (c) 2018 Actian Corporation. All Rights Reserved.-->
+	<!-- Copyright (c) 2019 Actian Corporation. All Rights Reserved.-->
 	<APPLICATION name="UnitTestFramework">
 		<included_apps>
 			<row>
@@ -67,7 +67,7 @@ METHOD throwAssertionFailedError(
 }
 
 /**
- * Fails a test with the given errortext.
+ * Skips a test with the given errortext.
  *
  * @param errortext	The text to be printed
  * @param errorline	The line where the skipping occured
@@ -127,51 +127,62 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedDate is not null then
-		if expectedDate <> actualDate then
-			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedDate), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), '<NULL>') + '>',
-				errorline = p.linenumber,
-				errorexec =	p.Name);
-		endif;
-	endif;
 	if expectedInteger is not null then
-		if expectedInteger <> actualInteger then
+		if actualInteger is null or expectedInteger <> actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedInteger), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), '<NULL>') + '>',
+				'expected: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedFloat is not null then
-		if expectedFloat <> actualFloat then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar <> actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedFloat), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), '<NULL>') + '>',
+				'expected: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedMoney is not null then
-		if expectedMoney <> actualMoney then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat <> actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedMoney), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), '<NULL>') + '>',
+				'expected: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedVarchar is not null then
-		if expectedVarchar <> actualVarchar then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney <> actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedVarchar), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), '<NULL>') + '>',
+				'expected: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
+	elseif expectedDate is not null then
+		if actualDate is null or expectedDate <> actualDate then
+			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+				'expected: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
+	else
+		if actualInteger is not null then
+			actualVarchar = varchar(actualInteger);
+		elseif actualFloat is not null then
+			actualVarchar = varchar(actualFloat);
+		elseif actualMoney is not null then
+			actualVarchar = varchar(actualMoney);
+		elseif actualDate is not null then
+			actualVarchar = varchar(actualDate);
+		endif;
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL>'+
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	endif;	
 end
 
 /**
@@ -211,50 +222,61 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedDate is not null then
-		if expectedDate = actualDate then
-			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedDate), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), '<NULL>') + '>',
-				errorline = p.linenumber,
-				errorexec =	p.Name);
-		endif;
-	endif;
 	if expectedInteger is not null then
-		if expectedInteger = actualInteger then
+		if actualInteger is null or expectedInteger = actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedInteger), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), '<NULL>') + '>',
+				'expected not equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedFloat is not null then
-		if expectedFloat = actualFloat then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar = actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedFloat), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), '<NULL>') + '>',
+				'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedMoney is not null then
-		if expectedMoney = actualMoney then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat = actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedMoney), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), '<NULL>') + '>',
+				'expected not equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedVarchar is not null then
-		if expectedVarchar = actualVarchar then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney = actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedVarchar), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), '<NULL>') + '>',
+				'expected not equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
+	elseif expectedDate is not null then
+		if actualDate is null or expectedDate = actualDate then
+			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+				'expected not equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
+	else
+		if actualInteger is not null then
+			actualVarchar = varchar(actualInteger);
+		elseif actualFloat is not null then
+			actualVarchar = varchar(actualFloat);
+		elseif actualMoney is not null then
+			actualVarchar = varchar(actualMoney);
+		elseif actualDate is not null then
+			actualVarchar = varchar(actualDate);
+		endif;
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL>'+
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
 	endif;
 end
 
@@ -294,51 +316,62 @@ declare
 	p = ProcExec DEFAULT NULL;
 enddeclare
 begin
-	p = ProcExec(CurMethod.Parent);
-	if expectedDate is not null then
-		if expectedDate <= actualDate then
-			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedDate), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), '<NULL>') + '>',
-				errorline = p.linenumber,
-				errorexec =	p.Name);
-		endif;
-	endif;
+	p = ProcExec(CurMethod.Parent);	
 	if expectedInteger is not null then
-		if expectedInteger <= actualInteger then
+		if actualInteger is null or expectedInteger <= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedInteger), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), '<NULL>') + '>',
+				'expected less than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedFloat is not null then
-		if expectedFloat <= actualFloat then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar <= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedFloat), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), '<NULL>') + '>',
+				'expected less than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedMoney is not null then
-		if expectedMoney <= actualMoney then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat <= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedMoney), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), '<NULL>') + '>',
+				'expected less than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedVarchar is not null then
-		if expectedVarchar <= actualVarchar then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney <= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedVarchar), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), '<NULL>') + '>',
+				'expected less than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
+	elseif expectedDate is not null then
+		if actualDate is null or expectedDate <= actualDate then
+			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+				'expected less than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
+	else
+		if actualInteger is not null then
+			actualVarchar = varchar(actualInteger);
+		elseif actualFloat is not null then
+			actualVarchar = varchar(actualFloat);
+		elseif actualMoney is not null then
+			actualVarchar = varchar(actualMoney);
+		elseif actualDate is not null then
+			actualVarchar = varchar(actualDate);
+		endif;
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL>'+
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
 	endif;
 end
 
@@ -379,50 +412,61 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedDate is not null then
-		if expectedDate < actualDate then
-			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + ifnull(varchar(expectedDate), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), '<NULL>') + '>',
-				errorline = p.linenumber,
-				errorexec =	p.Name);
-		endif;
-	endif;
 	if expectedInteger is not null then
-		if expectedInteger < actualInteger then
+		if actualInteger is null or expectedInteger < actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + ifnull(varchar(expectedInteger), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), '<NULL>') + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedFloat is not null then
-		if expectedFloat < actualFloat then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar < actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	less or equals: <' + ifnull(varchar(expectedFloat), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), '<NULL>') + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedMoney is not null then
-		if expectedMoney < actualMoney then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat < actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	less or equals: <' + ifnull(varchar(expectedMoney), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), '<NULL>') + '>',
+				'expected	less or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedVarchar is not null then
-		if expectedVarchar < actualVarchar then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney < actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + ifnull(varchar(expectedVarchar), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), '<NULL>') + '>',
+				'expected	less or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
+	elseif expectedDate is not null then
+		if actualDate is null or expectedDate < actualDate then
+			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+				'expected less or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
+	else
+		if actualInteger is not null then
+			actualVarchar = varchar(actualInteger);
+		elseif actualFloat is not null then
+			actualVarchar = varchar(actualFloat);
+		elseif actualMoney is not null then
+			actualVarchar = varchar(actualMoney);
+		elseif actualDate is not null then
+			actualVarchar = varchar(actualDate);
+		endif;
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL>'+
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
 	endif;
 end
 
@@ -463,51 +507,62 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedDate is not null then
-		if expectedDate >= actualDate then
-			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedDate), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), '<NULL>') + '>',
-				errorline = p.linenumber,
-				errorexec =	p.Name);
-		endif;
-	endif;
 	if expectedInteger is not null then
-		if expectedInteger >= actualInteger then
+		if actualInteger is null or expectedInteger >= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedInteger), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), '<NULL>') + '>',
+				'expected greater than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedFloat is not null then
-		if expectedFloat >= actualFloat then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar >= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedFloat), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), '<NULL>') + '>',
+				'expected greater than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedMoney is not null then
-		if expectedMoney >= actualMoney then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat >= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedMoney), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), '<NULL>') + '>',
+				'expected greater than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedVarchar is not null then
-		if expectedVarchar >= actualVarchar then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney >= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedVarchar), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), '<NULL>') + '>',
+				'expected greater than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
+	elseif expectedDate is not null then
+		if expectedDate is null or expectedDate >= actualDate then
+			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+				'expected greater than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
+	else
+		if actualInteger is not null then
+			actualVarchar = varchar(actualInteger);
+		elseif actualFloat is not null then
+			actualVarchar = varchar(actualFloat);
+		elseif actualMoney is not null then
+			actualVarchar = varchar(actualMoney);
+		elseif actualDate is not null then
+			actualVarchar = varchar(actualDate);
+		endif;
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL>'+
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	endif;	
 end
 
 /**
@@ -547,50 +602,61 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedDate is not null then
-		if expectedDate > actualDate then
-			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + ifnull(varchar(expectedDate), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), '<NULL>') + '>',
-				errorline = p.linenumber,
-				errorexec =	p.Name);
-		endif;
-	endif;
 	if expectedInteger is not null then
-		if expectedInteger > actualInteger then
+		if actualInteger is null or expectedInteger > actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + ifnull(varchar(expectedInteger), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), '<NULL>') + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedFloat is not null then
-		if expectedFloat > actualFloat then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar > actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	greater or equals: <' + ifnull(varchar(expectedFloat), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), '<NULL>') + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedMoney is not null then
-		if expectedMoney > actualMoney then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat > actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	greater or equals: <' + ifnull(varchar(expectedMoney), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), '<NULL>') + '>',
+				'expected	greater or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	endif;
-	if expectedVarchar is not null then
-		if expectedVarchar > actualVarchar then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney > actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + ifnull(varchar(expectedVarchar), '<NULL>') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), '<NULL>') + '>',
+				'expected	greater or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
+	elseif expectedDate is not null then
+		if actualDate is null or expectedDate > actualDate then
+			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+				'expected greater or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
+	else
+		if actualInteger is not null then
+			actualVarchar = varchar(actualInteger);
+		elseif actualFloat is not null then
+			actualVarchar = varchar(actualFloat);
+		elseif actualMoney is not null then
+			actualVarchar = varchar(actualMoney);
+		elseif actualDate is not null then
+			actualVarchar = varchar(actualDate);
+		endif;
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL>'+
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
 	endif;
 end
 
@@ -672,13 +738,23 @@ end
  * Asserts that an object reference is NULL.
  * If it is not, an AssertionFailedError is thrown with the given errortext.
  *
- * @param errortext	The error text to be printed
- * @param actual	The actual object reference
+ * @param errortext	        The error text to be printed
+ * @param actual	        The actual object reference
+ * @param actualInteger		The actual integer value
+ * @param actualFloat		The actual float value
+ * @param actualMoney		The actual money value
+ * @param actualDate		The actual date value
+ * @param actualVarchar		The actual varchar value
  *
  */
 METHOD assertNull (
 	errortext = varchar(2000) not null;
 	actual = Object default null;
+	actualInteger = Integer default null;
+	actualFloat = Float default null;
+	actualMoney = Money default null;
+	actualDate = Date default null;
+	actualVarchar = varchar(4096) default null;
 ) =
 declare
 	p = ProcExec DEFAULT NULL;
@@ -690,6 +766,31 @@ begin
 			'expected: <NULL> actual: ' + actual.ClassName,
 			errorline = p.linenumber,
 			errorexec =	p.Name);
+	elseif actualInteger IS NOT NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL> actual: ' + ifnull(varchar(actualInteger), '<NULL>'),
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualFloat IS NOT NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL> actual: ' + ifnull(varchar(actualFloat), '<NULL>'),
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualMoney IS NOT NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL> actual: ' + ifnull(varchar(actualMoney), '<NULL>'),
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualDate IS NOT NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL> actual: ' + ifnull(varchar(actualDate), '<NULL>'),
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualVarchar IS NOT NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <NULL> actual: ' + ifnull(varchar(actualVarchar), '<NULL>'),
+			errorline = p.linenumber,
+			errorexec =	p.Name);
 	endif;
 end
 
@@ -699,11 +800,21 @@ end
  *
  * @param errortext	The error text to be printed
  * @param actual	The actual object reference
+ * @param actualInteger		The actual integer value
+ * @param actualFloat		The actual float value
+ * @param actualMoney		The actual money value
+ * @param actualDate		The actual date value
+ * @param actualVarchar		The actual varchar value
  *
  */
 METHOD assertNotNull (
 	errortext = varchar(2000) not null;
-	actual = Object default null;
+	actual = Object;
+	actualInteger = Integer;
+	actualFloat = Float;
+	actualMoney = Money;
+	actualDate = Date;
+	actualVarchar = varchar(4096);
 ) =
 declare
 	p = ProcExec DEFAULT NULL;
@@ -715,9 +826,33 @@ begin
 			'expected: <Object not null> actual: <NULL object>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
+	elseif actualInteger IS NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <Integer not null> actual: <NULL Integer>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualFloat IS NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <Float not null> actual: <NULL Float>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualMoney IS NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <Money not null> actual: <NULL Money>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualDate IS NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <Date not null> actual: <NULL Date>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
+	elseif actualVarchar IS NULL then
+		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
+			'expected: <Varchar not null> actual: <NULL Varchar>',
+			errorline = p.linenumber,
+			errorexec =	p.Name);
 	endif;
-end
-]]>
+end]]>
 		</script>
 		<methods>
 			<row>

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -127,40 +127,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null and actualInteger is not null then
-		if expectedInteger <> actualInteger then
+	if expectedInteger is not null then
+		if actualInteger is null or expectedInteger <> actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null and actualVarchar is not null then
-		if expectedVarchar <> actualVarchar then
+	elseif expectedVarchar is not null then
+		if actualVarchar is null or expectedVarchar <> actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null and actualFloat is not null then
-		if expectedFloat <> actualFloat then
+	elseif expectedFloat is not null then
+		if actualFloat is null or expectedFloat <> actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null and actualMoney is not null then
-		if expectedMoney <> actualMoney then
+	elseif expectedMoney is not null then
+		if actualMoney is null or expectedMoney <> actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null and actualDate is not null then
-		if expectedDate <> actualDate then
+	elseif expectedDate is not null then
+		if actualDate is null or expectedDate <> actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -168,9 +168,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
-		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
-			errorline = p.linenumber,
-			errorexec =	p.Name);
+		if actualInteger is not null
+		or actualVarchar is not null
+		or actualFloat is not null
+		or actualMoney is not null
+		or actualDate is not null then
+			CurObject.throwAssertionFailedError(errortext='Expected parameter is missing!',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
 	endif;
 end
 
@@ -211,40 +217,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null and actualInteger is not null then
-		if expectedInteger = actualInteger then
+	if expectedInteger is not null then
+		if actualInteger is not null or expectedInteger = actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null and actualVarchar is not null then
-		if expectedVarchar = actualVarchar then
+	elseif expectedVarchar is not null then
+		if actualVarchar is not null or expectedVarchar = actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null and actualFloat is not null then
-		if expectedFloat = actualFloat then
+	elseif expectedFloat is not null then
+		if actualFloat is not null or expectedFloat = actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null and actualMoney is not null then
-		if expectedMoney = actualMoney then
+	elseif expectedMoney is not null then
+		if actualMoney is not null or expectedMoney = actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null and actualDate is not null then
-		if expectedDate = actualDate then
+	elseif expectedDate is not null then
+		if actualDate is not null or expectedDate = actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -252,9 +258,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
-		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
-			errorline = p.linenumber,
-			errorexec =	p.Name);
+		if actualInteger is null
+		and actualVarchar is null
+		and actualFloat is null
+		and actualMoney is null
+		and actualDate is null then
+			CurObject.throwAssertionFailedError(errortext='Expected parameter is missing!',
+				errorline = p.linenumber,
+				errorexec =	p.Name);
+		endif;
 	endif;
 end
 
@@ -702,27 +714,27 @@ begin
 			errorexec =	p.Name);
 	elseif actualInteger IS NOT NULL then
 		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL> actual: ' + ifnull(varchar(actualInteger), '<NULL>'),
+			'expected: <NULL> actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	elseif actualFloat IS NOT NULL then
 		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL> actual: ' + ifnull(varchar(actualFloat), '<NULL>'),
+			'expected: <NULL> actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	elseif actualMoney IS NOT NULL then
 		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL> actual: ' + ifnull(varchar(actualMoney), '<NULL>'),
+			'expected: <NULL> actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	elseif actualDate IS NOT NULL then
 		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL> actual: ' + ifnull(varchar(actualDate), '<NULL>'),
+			'expected: <NULL>actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	elseif actualVarchar IS NOT NULL then
 		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL> actual: ' + ifnull(varchar(actualVarchar), '<NULL>'),
+			'expected: <NULL> actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -218,7 +218,7 @@ enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
 	if expectedInteger is not null then
-		if actualInteger is not null or expectedInteger = actualInteger then
+		if actualInteger is not null and expectedInteger = actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
@@ -226,7 +226,7 @@ begin
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null then
-		if actualVarchar is not null or expectedVarchar = actualVarchar then
+		if actualVarchar is not null and expectedVarchar = actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
@@ -234,7 +234,7 @@ begin
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null then
-		if actualFloat is not null or expectedFloat = actualFloat then
+		if actualFloat is not null and expectedFloat = actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
@@ -242,7 +242,7 @@ begin
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null then
-		if actualMoney is not null or expectedMoney = actualMoney then
+		if actualMoney is not null and expectedMoney = actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
@@ -250,7 +250,7 @@ begin
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null then
-		if actualDate is not null or expectedDate = actualDate then
+		if actualDate is not null and expectedDate = actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -22,7 +22,7 @@
  *
  * @author	Bodo Bergmann
  */
- 
+
 
 /**
  * Fails a test with the given errortext.
@@ -35,7 +35,7 @@
 METHOD fail(
 	errortext = varchar(2000) not null,
 	errorline = integer not null,
-	errorexec = varchar(100) not null	
+	errorexec = varchar(100) not null
 )=
 {
 	G_Error = Error.Create();
@@ -56,7 +56,7 @@ METHOD fail(
 METHOD throwAssertionFailedError(
 	errortext = varchar(2000) not null,
 	errorline = integer not null,
-	errorexec = varchar(100) not null	
+	errorexec = varchar(100) not null
 )=
 {
 	G_Error = AssertionFailedError.Create();
@@ -67,7 +67,7 @@ METHOD throwAssertionFailedError(
 }
 
 /**
- * Skips a test with the given errortext.
+ * Fails a test with the given errortext.
  *
  * @param errortext	The text to be printed
  * @param errorline	The line where the skipping occured
@@ -127,40 +127,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null then
-		if actualInteger is null or expectedInteger <> actualInteger then
+	if expectedInteger is not null and actualInteger is not null then
+		if expectedInteger <> actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null then
-		if actualVarchar is null or expectedVarchar <> actualVarchar then
+	elseif expectedVarchar is not null and actualVarchar is not null then
+		if expectedVarchar <> actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null then
-		if actualFloat is null or expectedFloat <> actualFloat then
+	elseif expectedFloat is not null and actualFloat is not null then
+		if expectedFloat <> actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null then
-		if actualMoney is null or expectedMoney <> actualMoney then
+	elseif expectedMoney is not null and actualMoney is not null then
+		if expectedMoney <> actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null then
-		if actualDate is null or expectedDate <> actualDate then
+	elseif expectedDate is not null and actualDate is not null then
+		if expectedDate <> actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -168,6 +168,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
+		if expectedInteger is not null then
+			expectedVarchar = varchar(expectedInteger);
+		elseif expectedFloat is not null then
+			expectedVarchar = varchar(expectedFloat);
+		elseif expectedMoney is not null then
+			expectedVarchar = varchar(expectedMoney);
+		elseif expectedDate is not null then
+			expectedVarchar = varchar(expectedDate);
+		endif;
 		if actualInteger is not null then
 			actualVarchar = varchar(actualInteger);
 		elseif actualFloat is not null then
@@ -177,12 +186,12 @@ begin
 		elseif actualDate is not null then
 			actualVarchar = varchar(actualDate);
 		endif;
-		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL>'+
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
+			'expected: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
-	endif;	
+	endif;
 end
 
 /**
@@ -222,40 +231,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null then
-		if actualInteger is null or expectedInteger = actualInteger then
+	if expectedInteger is not null and actualInteger is not null then
+		if expectedInteger = actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null then
-		if actualVarchar is null or expectedVarchar = actualVarchar then
+	elseif expectedVarchar is not null and actualVarchar is not null then
+		if expectedVarchar = actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null then
-		if actualFloat is null or expectedFloat = actualFloat then
+	elseif expectedFloat is not null and actualFloat is not null then
+		if expectedFloat = actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null then
-		if actualMoney is null or expectedMoney = actualMoney then
+	elseif expectedMoney is not null and actualMoney is not null then
+		if expectedMoney = actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null then
-		if actualDate is null or expectedDate = actualDate then
+	elseif expectedDate is not null and actualDate is not null then
+		if expectedDate = actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected not equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -263,6 +272,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
+		if expectedInteger is not null then
+			expectedVarchar = varchar(expectedInteger);
+		elseif expectedFloat is not null then
+			expectedVarchar = varchar(expectedFloat);
+		elseif expectedMoney is not null then
+			expectedVarchar = varchar(expectedMoney);
+		elseif expectedDate is not null then
+			expectedVarchar = varchar(expectedDate);
+		endif;
 		if actualInteger is not null then
 			actualVarchar = varchar(actualInteger);
 		elseif actualFloat is not null then
@@ -272,9 +290,9 @@ begin
 		elseif actualDate is not null then
 			actualVarchar = varchar(actualDate);
 		endif;
-		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL>'+
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
+			'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -316,41 +334,41 @@ declare
 	p = ProcExec DEFAULT NULL;
 enddeclare
 begin
-	p = ProcExec(CurMethod.Parent);	
-	if expectedInteger is not null then
-		if actualInteger is null or expectedInteger <= actualInteger then
+	p = ProcExec(CurMethod.Parent);
+	if expectedInteger is not null and actualInteger is not null then
+		if expectedInteger <= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null then
-		if actualVarchar is null or expectedVarchar <= actualVarchar then
+	elseif expectedVarchar is not null and actualVarchar is not null then
+		if expectedVarchar <= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null then
-		if actualFloat is null or expectedFloat <= actualFloat then
+	elseif expectedFloat is not null and actualFloat is not null then
+		if expectedFloat <= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null then
-		if actualMoney is null or expectedMoney <= actualMoney then
+	elseif expectedMoney is not null and actualMoney is not null then
+		if expectedMoney <= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null then
-		if actualDate is null or expectedDate <= actualDate then
+	elseif expectedDate is not null and actualDate is not null then
+		if expectedDate <= actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -358,6 +376,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
+		if expectedInteger is not null then
+			expectedVarchar = varchar(expectedInteger);
+		elseif expectedFloat is not null then
+			expectedVarchar = varchar(expectedFloat);
+		elseif expectedMoney is not null then
+			expectedVarchar = varchar(expectedMoney);
+		elseif expectedDate is not null then
+			expectedVarchar = varchar(expectedDate);
+		endif;
 		if actualInteger is not null then
 			actualVarchar = varchar(actualInteger);
 		elseif actualFloat is not null then
@@ -367,9 +394,9 @@ begin
 		elseif actualDate is not null then
 			actualVarchar = varchar(actualDate);
 		endif;
-		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL>'+
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
+			'expected less than: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -412,40 +439,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null then
-		if actualInteger is null or expectedInteger < actualInteger then
+	if expectedInteger is not null and actualInteger is not null then
+		if expectedInteger < actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null then
-		if actualVarchar is null or expectedVarchar < actualVarchar then
+	elseif expectedVarchar is not null and actualVarchar is not null then
+		if expectedVarchar < actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null then
-		if actualFloat is null or expectedFloat < actualFloat then
+	elseif expectedFloat is not null and actualFloat is not null then
+		if expectedFloat < actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected	less or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null then
-		if actualMoney is null or expectedMoney < actualMoney then
+	elseif expectedMoney is not null and actualMoney is not null then
+		if expectedMoney < actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected	less or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null then
-		if actualDate is null or expectedDate < actualDate then
+	elseif expectedDate is not null and actualDate is not null then
+		if expectedDate < actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected less or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -453,6 +480,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
+		if expectedInteger is not null then
+			expectedVarchar = varchar(expectedInteger);
+		elseif expectedFloat is not null then
+			expectedVarchar = varchar(expectedFloat);
+		elseif expectedMoney is not null then
+			expectedVarchar = varchar(expectedMoney);
+		elseif expectedDate is not null then
+			expectedVarchar = varchar(expectedDate);
+		endif;
 		if actualInteger is not null then
 			actualVarchar = varchar(actualInteger);
 		elseif actualFloat is not null then
@@ -462,9 +498,9 @@ begin
 		elseif actualDate is not null then
 			actualVarchar = varchar(actualDate);
 		endif;
-		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL>'+
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
+			'expected less or equals: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -507,40 +543,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null then
-		if actualInteger is null or expectedInteger >= actualInteger then
+	if expectedInteger is not null and actualInteger is not null then
+		if expectedInteger >= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null then
-		if actualVarchar is null or expectedVarchar >= actualVarchar then
+	elseif expectedVarchar is not null and actualVarchar is not null then
+		if expectedVarchar >= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null then
-		if actualFloat is null or expectedFloat >= actualFloat then
+	elseif expectedFloat is not null and actualFloat is not null then
+		if expectedFloat >= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null then
-		if actualMoney is null or expectedMoney >= actualMoney then
+	elseif expectedMoney is not null and actualMoney is not null then
+		if expectedMoney >= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null then
-		if expectedDate is null or expectedDate >= actualDate then
+	elseif expectedDate is not null and actualDate is not null then
+		if expectedDate >= actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -548,6 +584,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
+		if expectedInteger is not null then
+			expectedVarchar = varchar(expectedInteger);
+		elseif expectedFloat is not null then
+			expectedVarchar = varchar(expectedFloat);
+		elseif expectedMoney is not null then
+			expectedVarchar = varchar(expectedMoney);
+		elseif expectedDate is not null then
+			expectedVarchar = varchar(expectedDate);
+		endif;
 		if actualInteger is not null then
 			actualVarchar = varchar(actualInteger);
 		elseif actualFloat is not null then
@@ -557,12 +602,12 @@ begin
 		elseif actualDate is not null then
 			actualVarchar = varchar(actualDate);
 		endif;
-		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL>'+
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
+			'expected greater than: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
-	endif;	
+	endif;
 end
 
 /**
@@ -602,40 +647,40 @@ declare
 enddeclare
 begin
 	p = ProcExec(CurMethod.Parent);
-	if expectedInteger is not null then
-		if actualInteger is null or expectedInteger > actualInteger then
+	if expectedInteger is not null and actualInteger is not null then
+		if expectedInteger > actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedVarchar is not null then
-		if actualVarchar is null or expectedVarchar > actualVarchar then
+	elseif expectedVarchar is not null and actualVarchar is not null then
+		if expectedVarchar > actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedFloat is not null then
-		if actualFloat is null or expectedFloat > actualFloat then
+	elseif expectedFloat is not null and actualFloat is not null then
+		if expectedFloat > actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected	greater or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedMoney is not null then
-		if actualMoney is null or expectedMoney > actualMoney then
+	elseif expectedMoney is not null and actualMoney is not null then
+		if expectedMoney > actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected	greater or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
-	elseif expectedDate is not null then
-		if actualDate is null or expectedDate > actualDate then
+	elseif expectedDate is not null and actualDate is not null then
+		if expectedDate > actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
 				'expected greater or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
 				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
@@ -643,6 +688,15 @@ begin
 				errorexec =	p.Name);
 		endif;
 	else
+		if expectedInteger is not null then
+			expectedVarchar = varchar(expectedInteger);
+		elseif expectedFloat is not null then
+			expectedVarchar = varchar(expectedFloat);
+		elseif expectedMoney is not null then
+			expectedVarchar = varchar(expectedMoney);
+		elseif expectedDate is not null then
+			expectedVarchar = varchar(expectedDate);
+		endif;
 		if actualInteger is not null then
 			actualVarchar = varchar(actualInteger);
 		elseif actualFloat is not null then
@@ -652,9 +706,9 @@ begin
 		elseif actualDate is not null then
 			actualVarchar = varchar(actualDate);
 		endif;
-		CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-			'expected: <NULL>'+
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
+			'expected greater or equals: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
+			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -735,7 +789,7 @@ begin
 end
 
 /**
- * Asserts that an object reference is NULL.
+ * Asserts that an object reference or a variable is NULL.
  * If it is not, an AssertionFailedError is thrown with the given errortext.
  *
  * @param errortext	        The error text to be printed
@@ -795,7 +849,7 @@ begin
 end
 
 /**
- * Asserts that an object reference is not NULL.
+ * Asserts that an object reference or a variable is not NULL.
  * If it is NULL, an AssertionFailedError is thrown with the given errortext.
  *
  * @param errortext	The error text to be printed

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -92,7 +92,7 @@ end
 /**
  * Asserts that two values are equal.
  * If they are not equal, an AssertionFailedError is thrown with the given errortext.
- * Apart from the "errortext" parameters exactly one pair of matching
+ * Apart from the "errortext" parameters exactly one pair of matching and non-null
  * "expected..." and "actual..." parameters for the same datatype should be passed.
  *
  * @param errortext		The error text to be printed
@@ -115,8 +115,8 @@ METHOD assertEquals (
 	actualInteger = Integer8 default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
-	expectedMoney = Float default null;
-	actualMoney = Float default null;
+	expectedMoney = Money default null;
+	actualMoney = Money default null;
 	expectedDate = Date default null;
 	actualDate = Date default null;
 	expectedVarchar = varchar(4096) default null;
@@ -130,65 +130,45 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger <> actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
+				'expected: <' + varchar(expectedInteger) + '>' +
+				' actual: <' + varchar(actualInteger) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar <> actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+				'expected: <' + varchar(expectedVarchar) + '>' +
+				' actual: <' + varchar(actualVarchar) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat <> actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
+				'expected: <' + varchar(expectedFloat) + '>' +
+				' actual: <' + varchar(actualFloat) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney <> actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
+				'expected: <' + varchar(expectedMoney) + '>' +
+				' actual: <' + varchar(actualMoney) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate <> actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				'expected: <' + varchar(expectedDate) + '>' +
+				' actual: <' + varchar(actualDate) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	else
-		if expectedInteger is not null then
-			expectedVarchar = varchar(expectedInteger);
-		elseif expectedFloat is not null then
-			expectedVarchar = varchar(expectedFloat);
-		elseif expectedMoney is not null then
-			expectedVarchar = varchar(expectedMoney);
-		elseif expectedDate is not null then
-			expectedVarchar = varchar(expectedDate);
-		endif;
-		if actualInteger is not null then
-			actualVarchar = varchar(actualInteger);
-		elseif actualFloat is not null then
-			actualVarchar = varchar(actualFloat);
-		elseif actualMoney is not null then
-			actualVarchar = varchar(actualMoney);
-		elseif actualDate is not null then
-			actualVarchar = varchar(actualDate);
-		endif;
-		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
-			'expected: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -197,7 +177,7 @@ end
 /**
  * Asserts that two values are not equal.
  * If they are equal, an AssertionFailedError is thrown with the given errortext.
- * Apart from the "errortext" parameters exactly one pair of matching
+ * Apart from the "errortext" parameters exactly one pair of matching and non-null
  * "expected..." and "actual..." parameters for the same datatype should be passed.
  *
  * @param errortext		The error text to be printed
@@ -219,8 +199,8 @@ METHOD assertNotEquals (
 	actualInteger = Integer8 default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
-	expectedMoney = Float default null;
-	actualMoney = Float default null;
+	expectedMoney = Money default null;
+	actualMoney = Money default null;
 	expectedDate = Date default null;
 	actualDate = Date default null;
 	expectedVarchar = varchar(4096) default null;
@@ -234,65 +214,45 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger = actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
+				'expected not equals: <' + varchar(expectedInteger) + '>' +
+				' actual: <' + varchar(actualInteger) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar = actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+				'expected not equals: <' + varchar(expectedVarchar) + '>' +
+				' actual: <' + varchar(actualVarchar) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat = actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
+				'expected not equals: <' + varchar(expectedFloat) + '>' +
+				' actual: <' + varchar(actualFloat) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney = actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
+				'expected not equals: <' + varchar(expectedMoney) + '>' +
+				' actual: <' + varchar(actualMoney) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate = actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				'expected not equals: <' + varchar(expectedDate) + '>' +
+				' actual: <' + varchar(actualDate) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	else
-		if expectedInteger is not null then
-			expectedVarchar = varchar(expectedInteger);
-		elseif expectedFloat is not null then
-			expectedVarchar = varchar(expectedFloat);
-		elseif expectedMoney is not null then
-			expectedVarchar = varchar(expectedMoney);
-		elseif expectedDate is not null then
-			expectedVarchar = varchar(expectedDate);
-		endif;
-		if actualInteger is not null then
-			actualVarchar = varchar(actualInteger);
-		elseif actualFloat is not null then
-			actualVarchar = varchar(actualFloat);
-		elseif actualMoney is not null then
-			actualVarchar = varchar(actualMoney);
-		elseif actualDate is not null then
-			actualVarchar = varchar(actualDate);
-		endif;
-		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
-			'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -301,7 +261,7 @@ end
 /**
  * Asserts that the actual value is less than the expected value.
  * If it is not, an AssertionFailedError is thrown with the given errortext.
- * Apart from the "errortext" parameters exactly one pair of matching
+ * Apart from the "errortext" parameters exactly one pair of matching and non-null
  * "expected..." and "actual..." parameters for the same datatype should be passed.
  *
  * @param errortext		The error text to be printed
@@ -323,8 +283,8 @@ METHOD assertLessThan (
 	actualInteger = Integer default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
-	expectedMoney = Float default null;
-	actualMoney = Float default null;
+	expectedMoney = Money default null;
+	actualMoney = Money default null;
 	expectedDate = Date default null;
 	actualDate = Date default null;
 	expectedVarchar = varchar(4096) default null;
@@ -338,65 +298,45 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger <= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
+				'expected less than: <' + varchar(expectedInteger) + '>' +
+				' actual: <' + varchar(actualInteger) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar <= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+				'expected less than: <' + varchar(expectedVarchar) + '>' +
+				' actual: <' + varchar(actualVarchar) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat <= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
+				'expected less than: <' + varchar(expectedFloat) + '>' +
+				' actual: <' + varchar(actualFloat) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney <= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
+				'expected less than: <' + varchar(expectedMoney) + '>' +
+				' actual: <' + varchar(actualMoney) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate <= actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				'expected less than: <' + varchar(expectedDate) + '>' +
+				' actual: <' + varchar(actualDate) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	else
-		if expectedInteger is not null then
-			expectedVarchar = varchar(expectedInteger);
-		elseif expectedFloat is not null then
-			expectedVarchar = varchar(expectedFloat);
-		elseif expectedMoney is not null then
-			expectedVarchar = varchar(expectedMoney);
-		elseif expectedDate is not null then
-			expectedVarchar = varchar(expectedDate);
-		endif;
-		if actualInteger is not null then
-			actualVarchar = varchar(actualInteger);
-		elseif actualFloat is not null then
-			actualVarchar = varchar(actualFloat);
-		elseif actualMoney is not null then
-			actualVarchar = varchar(actualMoney);
-		elseif actualDate is not null then
-			actualVarchar = varchar(actualDate);
-		endif;
-		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
-			'expected less than: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -405,7 +345,7 @@ end
 /**
  * Asserts that the actual value is less than or equal the expected value.
  * If it is not, an AssertionFailedError is thrown with the given errortext.
- * Apart from the "errortext" parameters exactly one pair of matching
+ * Apart from the "errortext" parameters exactly one pair of matching and non-null
  * "expected..." and "actual..." parameters for the same datatype should be passed.
  *
  * @param errortext		The error text to be printed
@@ -427,8 +367,8 @@ METHOD assertLessEquals (
 	actualInteger = Integer default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
-	expectedMoney = Float default null;
-	actualMoney = Float default null;
+	expectedMoney = Money default null;
+	actualMoney = Money default null;
 	expectedDate = Date default null;
 	actualDate = Date default null;
 	expectedVarchar = varchar(4096) default null;
@@ -442,65 +382,45 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger < actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
+				'expected less or equals: <' + varchar(expectedInteger) + '>' +
+				' actual: <' + varchar(actualInteger) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar < actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+				'expected less or equals: <' + varchar(expectedVarchar) + '>' +
+				' actual: <' + varchar(actualVarchar) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat < actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	less or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
+				'expected	less or equals: <' + varchar(expectedFloat) + '>' +
+				' actual: <' + varchar(actualFloat) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney < actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	less or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
+				'expected	less or equals: <' + varchar(expectedMoney) + '>' +
+				' actual: <' + varchar(actualMoney) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate < actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				'expected less or equals: <' + varchar(expectedDate) + '>' +
+				' actual: <' + varchar(actualDate) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	else
-		if expectedInteger is not null then
-			expectedVarchar = varchar(expectedInteger);
-		elseif expectedFloat is not null then
-			expectedVarchar = varchar(expectedFloat);
-		elseif expectedMoney is not null then
-			expectedVarchar = varchar(expectedMoney);
-		elseif expectedDate is not null then
-			expectedVarchar = varchar(expectedDate);
-		endif;
-		if actualInteger is not null then
-			actualVarchar = varchar(actualInteger);
-		elseif actualFloat is not null then
-			actualVarchar = varchar(actualFloat);
-		elseif actualMoney is not null then
-			actualVarchar = varchar(actualMoney);
-		elseif actualDate is not null then
-			actualVarchar = varchar(actualDate);
-		endif;
-		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
-			'expected less or equals: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -509,7 +429,7 @@ end
 /**
  * Asserts that the actual value is greater than the expected value.
  * If it is not, an AssertionFailedError is thrown with the given errortext.
- * Apart from the "errortext" parameters exactly one pair of matching
+ * Apart from the "errortext" parameters exactly one pair of matching and non-null
  * "expected..." and "actual..." parameters for the same datatype should be passed.
  *
  * @param errortext		The error text to be printed
@@ -531,8 +451,8 @@ METHOD assertGreaterThan (
 	actualInteger = Integer default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
-	expectedMoney = Float default null;
-	actualMoney = Float default null;
+	expectedMoney = Money default null;
+	actualMoney = Money default null;
 	expectedDate = Date default null;
 	actualDate = Date default null;
 	expectedVarchar = varchar(4096) default null;
@@ -546,65 +466,45 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger >= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
+				'expected greater than: <' + varchar(expectedInteger) + '>' +
+				' actual: <' + varchar(actualInteger) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar >= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+				'expected greater than: <' + varchar(expectedVarchar) + '>' +
+				' actual: <' + varchar(actualVarchar) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat >= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
+				'expected greater than: <' + varchar(expectedFloat) + '>' +
+				' actual: <' + varchar(actualFloat) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney >= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
+				'expected greater than: <' + varchar(expectedMoney) + '>' +
+				' actual: <' + varchar(actualMoney) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate >= actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				'expected greater than: <' + varchar(expectedDate) + '>' +
+				' actual: <' + varchar(actualDate) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	else
-		if expectedInteger is not null then
-			expectedVarchar = varchar(expectedInteger);
-		elseif expectedFloat is not null then
-			expectedVarchar = varchar(expectedFloat);
-		elseif expectedMoney is not null then
-			expectedVarchar = varchar(expectedMoney);
-		elseif expectedDate is not null then
-			expectedVarchar = varchar(expectedDate);
-		endif;
-		if actualInteger is not null then
-			actualVarchar = varchar(actualInteger);
-		elseif actualFloat is not null then
-			actualVarchar = varchar(actualFloat);
-		elseif actualMoney is not null then
-			actualVarchar = varchar(actualMoney);
-		elseif actualDate is not null then
-			actualVarchar = varchar(actualDate);
-		endif;
-		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
-			'expected greater than: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;
@@ -613,7 +513,7 @@ end
 /**
  * Asserts that the actual value is greater than or equal the expected value.
  * If it is not, an AssertionFailedError is thrown with the given errortext.
- * Apart from the "errortext" parameters exactly one pair of matching
+ * Apart from the "errortext" parameters exactly one pair of matching and non-null
  * "expected..." and "actual..." parameters for the same datatype should be passed.
  *
  * @param errortext		The error text to be printed
@@ -635,8 +535,8 @@ METHOD assertGreaterEquals (
 	actualInteger = Integer default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
-	expectedMoney = Float default null;
-	actualMoney = Float default null;
+	expectedMoney = Money default null;
+	actualMoney = Money default null;
 	expectedDate = Date default null;
 	actualDate = Date default null;
 	expectedVarchar = varchar(4096) default null;
@@ -650,65 +550,45 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger > actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
+				'expected greater or equals: <' + varchar(expectedInteger) + '>' +
+				' actual: <' + varchar(actualInteger) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar > actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
+				'expected greater or equals: <' + varchar(expectedVarchar) + '>' +
+				' actual: <' + varchar(actualVarchar) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat > actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	greater or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
+				'expected	greater or equals: <' + varchar(expectedFloat) + '>' +
+				' actual: <' + varchar(actualFloat) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney > actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	greater or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
+				'expected	greater or equals: <' + varchar(expectedMoney) + '>' +
+				' actual: <' + varchar(actualMoney) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate > actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
-				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
+				'expected greater or equals: <' + varchar(expectedDate) + '>' +
+				' actual: <' + varchar(actualDate) + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	else
-		if expectedInteger is not null then
-			expectedVarchar = varchar(expectedInteger);
-		elseif expectedFloat is not null then
-			expectedVarchar = varchar(expectedFloat);
-		elseif expectedMoney is not null then
-			expectedVarchar = varchar(expectedMoney);
-		elseif expectedDate is not null then
-			expectedVarchar = varchar(expectedDate);
-		endif;
-		if actualInteger is not null then
-			actualVarchar = varchar(actualInteger);
-		elseif actualFloat is not null then
-			actualVarchar = varchar(actualFloat);
-		elseif actualMoney is not null then
-			actualVarchar = varchar(actualMoney);
-		elseif actualDate is not null then
-			actualVarchar = varchar(actualDate);
-		endif;
-		CurObject.throwAssertionFailedError(errortext='Invalid Parameters Passed!'+HC_NEWLINE+HC_TAB+
-			'expected greater or equals: <' + ifnull(varchar(expectedVarchar), 'NULL/MISSING') + '>' +
-			' actual: <' + ifnull(varchar(actualVarchar), 'NULL/MISSING') + '>',
+		CurObject.throwAssertionFailedError(errortext='Invalid or missing parameters!',
 			errorline = p.linenumber,
 			errorexec =	p.Name);
 	endif;

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -130,40 +130,40 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger <> actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + varchar(expectedInteger) + '>' +
-				' actual: <' + varchar(actualInteger) + '>',
+				'expected: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar <> actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + varchar(expectedVarchar) + '>' +
-				' actual: <' + varchar(actualVarchar) + '>',
+				'expected: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat <> actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + varchar(expectedFloat) + '>' +
-				' actual: <' + varchar(actualFloat) + '>',
+				'expected: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney <> actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + varchar(expectedMoney) + '>' +
-				' actual: <' + varchar(actualMoney) + '>',
+				'expected: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate <> actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected: <' + varchar(expectedDate) + '>' +
-				' actual: <' + varchar(actualDate) + '>',
+				'expected: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
@@ -214,40 +214,40 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger = actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + varchar(expectedInteger) + '>' +
-				' actual: <' + varchar(actualInteger) + '>',
+				'expected not equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar = actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + varchar(expectedVarchar) + '>' +
-				' actual: <' + varchar(actualVarchar) + '>',
+				'expected not equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat = actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + varchar(expectedFloat) + '>' +
-				' actual: <' + varchar(actualFloat) + '>',
+				'expected not equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney = actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + varchar(expectedMoney) + '>' +
-				' actual: <' + varchar(actualMoney) + '>',
+				'expected not equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate = actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected not equals: <' + varchar(expectedDate) + '>' +
-				' actual: <' + varchar(actualDate) + '>',
+				'expected not equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
@@ -298,40 +298,40 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger <= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + varchar(expectedInteger) + '>' +
-				' actual: <' + varchar(actualInteger) + '>',
+				'expected less than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar <= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + varchar(expectedVarchar) + '>' +
-				' actual: <' + varchar(actualVarchar) + '>',
+				'expected less than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat <= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + varchar(expectedFloat) + '>' +
-				' actual: <' + varchar(actualFloat) + '>',
+				'expected less than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney <= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + varchar(expectedMoney) + '>' +
-				' actual: <' + varchar(actualMoney) + '>',
+				'expected less than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate <= actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less than: <' + varchar(expectedDate) + '>' +
-				' actual: <' + varchar(actualDate) + '>',
+				'expected less than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
@@ -382,40 +382,40 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger < actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + varchar(expectedInteger) + '>' +
-				' actual: <' + varchar(actualInteger) + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar < actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + varchar(expectedVarchar) + '>' +
-				' actual: <' + varchar(actualVarchar) + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat < actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	less or equals: <' + varchar(expectedFloat) + '>' +
-				' actual: <' + varchar(actualFloat) + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney < actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	less or equals: <' + varchar(expectedMoney) + '>' +
-				' actual: <' + varchar(actualMoney) + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate < actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected less or equals: <' + varchar(expectedDate) + '>' +
-				' actual: <' + varchar(actualDate) + '>',
+				'expected less or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
@@ -466,40 +466,40 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger >= actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + varchar(expectedInteger) + '>' +
-				' actual: <' + varchar(actualInteger) + '>',
+				'expected greater than: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar >= actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + varchar(expectedVarchar) + '>' +
-				' actual: <' + varchar(actualVarchar) + '>',
+				'expected greater than: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat >= actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + varchar(expectedFloat) + '>' +
-				' actual: <' + varchar(actualFloat) + '>',
+				'expected greater than: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney >= actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + varchar(expectedMoney) + '>' +
-				' actual: <' + varchar(actualMoney) + '>',
+				'expected greater than: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate >= actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater than: <' + varchar(expectedDate) + '>' +
-				' actual: <' + varchar(actualDate) + '>',
+				'expected greater than: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
@@ -550,40 +550,40 @@ begin
 	if expectedInteger is not null and actualInteger is not null then
 		if expectedInteger > actualInteger then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + varchar(expectedInteger) + '>' +
-				' actual: <' + varchar(actualInteger) + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedInteger), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualInteger), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedVarchar is not null and actualVarchar is not null then
 		if expectedVarchar > actualVarchar then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + varchar(expectedVarchar) + '>' +
-				' actual: <' + varchar(actualVarchar) + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedVarchar), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualVarchar), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedFloat is not null and actualFloat is not null then
 		if expectedFloat > actualFloat then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	greater or equals: <' + varchar(expectedFloat) + '>' +
-				' actual: <' + varchar(actualFloat) + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedFloat), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualFloat), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedMoney is not null and actualMoney is not null then
 		if expectedMoney > actualMoney then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected	greater or equals: <' + varchar(expectedMoney) + '>' +
-				' actual: <' + varchar(actualMoney) + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedMoney), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualMoney), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;
 	elseif expectedDate is not null and actualDate is not null then
 		if expectedDate > actualDate then
 			CurObject.throwAssertionFailedError(errortext=errortext+HC_NEWLINE+HC_TAB+
-				'expected greater or equals: <' + varchar(expectedDate) + '>' +
-				' actual: <' + varchar(actualDate) + '>',
+				'expected greater or equals: <' + ifnull(varchar(expectedDate), 'NULL') + '>' +
+				' actual: <' + ifnull(varchar(actualDate), 'NULL') + '>',
 				errorline = p.linenumber,
 				errorexec =	p.Name);
 		endif;


### PR DESCRIPTION
#### AssertEquals(), AssertNotEquals() methods
- 'Expected parameter is missing!' Error is thrown if expected parameter is null or missing.
- expectedMoney and actualMoney datatype changed to Money
- removed extra <> for NULLs in error message

#### AssertLessThan(), AssertLessEquals(), AssertGreaterThan(), AssertGreaterEquals() methods:
- As null values cannot be compared, null value in expected or actual parameter is invalid.
- 'Invalid or missing parameters!' Error is thrown if expected or actual parameter is null or missing.
- 'Invalid or missing parameters!' Error is also thrown if expected or actual parameter datatype is not same.
- method comments changed to pass non-null parameters
- expectedMoney and actualMoney datatype changed to Money
- removed extra <> for NULLs in error message

#### AssertNull() and AssertNotNull() methods:
- Added non object parameters(ActualInteger, ActualFloat, ActualMoney, ActualDate and ActualVarchar)
- method comments changed to include variable along with object

Note: [unittests.zip](https://github.com/ActianCorp/OpenROAD_UnitTestFramework/files/2783542/unittests.zip) are used to test the change.
