### PR TITLE
actual and expected datatype changed to Integer8 from Integer

### DIFF
--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -71,7 +71,7 @@ METHOD throwAssertionFailedError(
 }
 
 /**
- * Fails a test with the given errortext.
+ * Skips a test with the given errortext.
  *
  * @param errortext	The text to be printed
  * @param errorline	The line where the skipping occured
@@ -700,7 +700,7 @@ end
 METHOD assertNull (
 	errortext = varchar(2000) not null;
 	actual = Object default null;
-	actualInteger = Integer default null;
+	actualInteger = Integer8 default null;
 	actualFloat = Float default null;
 	actualMoney = Money default null;
 	actualDate = Date default null;
@@ -760,7 +760,7 @@ end
 METHOD assertNotNull (
 	errortext = varchar(2000) not null;
 	actual = Object;
-	actualInteger = Integer;
+	actualInteger = Integer8;
 	actualFloat = Float;
 	actualMoney = Money;
 	actualDate = Date;

--- a/unittests/UnitTestFramework.xml
+++ b/unittests/UnitTestFramework.xml
@@ -295,8 +295,8 @@ end
  */
 METHOD assertLessThan (
 	errortext = varchar(2000) not null;
-	expectedInteger = Integer default null;
-	actualInteger = Integer default null;
+	expectedInteger = Integer8 default null;
+	actualInteger = Integer8 default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
 	expectedMoney = Money default null;
@@ -379,8 +379,8 @@ end
  */
 METHOD assertLessEquals (
 	errortext = varchar(2000) not null;
-	expectedInteger = Integer default null;
-	actualInteger = Integer default null;
+	expectedInteger = Integer8 default null;
+	actualInteger = Integer8 default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
 	expectedMoney = Money default null;
@@ -463,8 +463,8 @@ end
  */
 METHOD assertGreaterThan (
 	errortext = varchar(2000) not null;
-	expectedInteger = Integer default null;
-	actualInteger = Integer default null;
+	expectedInteger = Integer8 default null;
+	actualInteger = Integer8 default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
 	expectedMoney = Money default null;
@@ -547,8 +547,8 @@ end
  */
 METHOD assertGreaterEquals (
 	errortext = varchar(2000) not null;
-	expectedInteger = Integer default null;
-	actualInteger = Integer default null;
+	expectedInteger = Integer8 default null;
+	actualInteger = Integer8 default null;
 	expectedFloat = Float default null;
 	actualFloat = Float default null;
 	expectedMoney = Money default null;


### PR DESCRIPTION
* actualInteger datatype is changed to Integer8 from Integer in assertNull() and assertNotNull() methods.
* actualInteger and expectedInteger datatype is changed to Integer8 from Integer in assertLessThan(), assertLessEquals(), assertGreaterThan(), assertGreaterEquals() methods.